### PR TITLE
add stuff

### DIFF
--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -171,8 +171,8 @@ class SelectApp(App):
 
         environment = []
 
-        if db['source']['db_password']:
-            environment.append(f"PASSWORD='${db['source']['db_password']}'")
+        if db['target']['db_password']:
+            environment.append(f"PASSWORD='${db['target']['db_password']}'")
 
         command = "pg_restore"
         arguments = [

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -13,6 +13,7 @@ from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.events import Print
 from textual.widgets import Button, Header, Log, Markdown, Select, Label, Input
+from textual.widgets import Checkbox
 
 root_dir = os.path.dirname(__file__)  # <-- absolute dir the script is in
 config_rel_path = "config.yaml"
@@ -36,6 +37,10 @@ class SelectApp(App):
                          Button.success("Validate", id="validate", disabled=True),
                          Label("--jobs"),
                          Input(placeholder="16"))
+        yield Horizontal(
+            Checkbox(id="no_owner", label="Discard owner information in dump and restore all objects to be owned by the target user", value=True),
+            Checkbox(id="no_privileges", label="Discard privileges information in dump and don't try to restore it", value=True),
+        )
         yield Markdown(id="db_config_markdown", markdown="")
         yield Log(auto_scroll=True)
 
@@ -125,13 +130,80 @@ class SelectApp(App):
         db_name = db["source"]["db_database_name"]
         return f"{path}/{db_name}"
 
-        
+
+    def construct_dump_command(self, db) -> str:
+        dump_path = self.construct_path_to_dump(db)
+        jobs = self.query_one(Input).value or 16
+
+        environment = []
+
+        if db['source']['db_password']:
+            environment.append(f"PASSWORD='${db['source']['db_password']}'")
+
+        command = "pg_dump"
+        arguments = [
+            f"-h {db['source']['db_connection_host']}",
+            f"-p {db['source'].get('port', 5432)}",
+            f"-U {db['source']['db_username']}",
+            f"-d {db['source']['db_database_name']}",
+            "-T '*awsdms*'",
+            "--create",
+            "--clean",
+            "--encoding utf8",
+            "--format directory",
+            f"--jobs {jobs}",
+            "-Z 0",
+            "-v",
+            f"--file={dump_path}"
+        ]
+
+        if self.query_one("#no_owner").value:
+            arguments.append("--no-owner")
+
+        if self.query_one("#no_privileges").value:
+            arguments.append("--no-privileges")
+
+        return " ".join(environment + [command] + arguments)
+
+
+    def construct_restore_command(self, db) -> str:
+        dump_path = self.construct_path_to_dump(db)
+
+        environment = []
+
+        if db['source']['db_password']:
+            environment.append(f"PASSWORD='${db['source']['db_password']}'")
+
+        command = "pg_restore"
+        arguments = [
+            f"-h {db['source']['db_connection_host']}",
+            f"-p {db['source'].get('port', 5432)}",
+            f"-U {db['source']['db_username']}",
+            f"-d {db['source']['db_database_name']}",
+            "--clean",
+            "--if-exists",
+            "--single-transaction",
+            "--exit-on-error",
+            "--format directory",
+            "-vv",
+        ]
+
+        if self.query_one("#no_owner").value:
+            arguments.append("--no-owner")
+
+        if self.query_one("#no_privileges").value:
+            arguments.append("--no-privileges")
+
+        arguments.append(dump_path)
+
+        return " ".join(environment + [command] + arguments)
+
     def generate_pg_dump_and_restore_cmd(self, event: Select.Changed)-> str:
         jobs = self.query_one(Input).value or 16
         db = config["dbs"][event.value]
         dump_path = self.construct_path_to_dump(db)
-        pg_dump_cmd = f'PGPASSWORD=\'{db['source']['db_password']}\' pg_dump -T \'*awsdms*\' -h {db['source']['db_connection_host']} -p {db['source'].get('port', 5432)} -U {db['source']['db_username']} -d {db['source']['db_database_name']} --create --clean --encoding utf8 --format directory --jobs {jobs} -Z 0 -v --file={dump_path}'
-        pg_restore_cmd = f'PGPASSWORD=\'{db['target']['db_password']}\' pg_restore -h {db['target']['db_connection_host']} -p {db['target'].get('port', 5432)} -U {db['target']['db_username']} -d {db['target']['db_database_name']} --clean --if-exists --single-transaction --exit-on-error --format directory -vv {dump_path}'
+        pg_dump_cmd = self.construct_dump_command(db)
+        pg_restore_cmd = self.construct_restore_command(db)
         finished_cmd = 'echo "THE MIGRATION HAS FINISHED!!! pg_restore exit code: $?"'
 
         cmd = " && /\n ".join([pg_dump_cmd, pg_restore_cmd])
@@ -148,6 +220,9 @@ class SelectApp(App):
             self.query_one(Select).disabled = True
             self.begin_capture_print(self, True, True)
             self.run_cmd(self.CMD)
+            self.query_one(Log).focus()
+            self.query_one(Select).disabled = False
+            event.button.disabled = False
         elif event.button.id == "validate":
             event.button.disabled = True
             asyncio.create_task(self.validate_migration())

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -154,7 +154,7 @@ class SelectApp(App):
             f"--jobs {jobs}",
             "-Z 0",
             "-v",
-            f"--file={dump_path}"
+            f"--file={dump_path}",
         ]
 
         if self.query_one("#no_owner").value:

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -214,6 +214,7 @@ class SelectApp(App):
     @on(Button.Pressed)
     def button_pressed(self, event: Button.Pressed):
         if event.button.id == "migrate":
+            self.query_one(Log).clear()
             self.begin_capture_print(self, True, True)
             self.run_cmd(self.CMD)
             self.query_one(Log).focus()

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -216,13 +216,9 @@ class SelectApp(App):
     @on(Button.Pressed)
     def button_pressed(self, event: Button.Pressed):
         if event.button.id == "migrate":
-            event.button.disabled = True
-            self.query_one(Select).disabled = True
             self.begin_capture_print(self, True, True)
             self.run_cmd(self.CMD)
             self.query_one(Log).focus()
-            self.query_one(Select).disabled = False
-            event.button.disabled = False
         elif event.button.id == "validate":
             event.button.disabled = True
             asyncio.create_task(self.validate_migration())
@@ -284,6 +280,8 @@ class SelectApp(App):
 
             await source_conn.close()
             await target_conn.close()
+
+            self.query_one("validate").disabled = False
 
 
     @on(Print)

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -199,9 +199,7 @@ class SelectApp(App):
         return " ".join(environment + [command] + arguments)
 
     def generate_pg_dump_and_restore_cmd(self, event: Select.Changed)-> str:
-        jobs = self.query_one(Input).value or 16
         db = config["dbs"][event.value]
-        dump_path = self.construct_path_to_dump(db)
         pg_dump_cmd = self.construct_dump_command(db)
         pg_restore_cmd = self.construct_restore_command(db)
         finished_cmd = 'echo "THE MIGRATION HAS FINISHED!!! pg_restore exit code: $?"'

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -176,10 +176,10 @@ class SelectApp(App):
 
         command = "pg_restore"
         arguments = [
-            f"-h {db['source']['db_connection_host']}",
-            f"-p {db['source'].get('port', 5432)}",
-            f"-U {db['source']['db_username']}",
-            f"-d {db['source']['db_database_name']}",
+            f"-h {db['target']['db_connection_host']}",
+            f"-p {db['target'].get('port', 5432)}",
+            f"-U {db['target']['db_username']}",
+            f"-d {db['target']['db_database_name']}",
             "--clean",
             "--if-exists",
             "--single-transaction",


### PR DESCRIPTION
* refactor building of dump and restore commands into cleaner functions
* add options (enabled by default) to discard owner and privileges in dump/restore
* don't disable the migration buttons after migration is started
* re-enable the validation button after it's finished
* autofocus on log field when migration is started
* password is only added to the commands if it's not None
* clear log before starting new migration