### PR TITLE
Many changes

### DIFF
--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -60,7 +60,7 @@ class SelectApp(App):
             self.query_one("#migrate").disabled = False
             self.query_one("#validate").disabled = False
             self.DUMP_PATH = self.construct_path_to_dump(config["dbs"][event.value])
-            self.CMD = self.generate_pg_dump_and_restore_cmd(event)
+            self.CMD = self.generate_cmd(event)
 
     def clean_old_dumps(self, db):
         self.query_one(Log).clear()
@@ -198,7 +198,7 @@ class SelectApp(App):
 
         return " ".join(environment + [command] + arguments)
 
-    def generate_pg_dump_and_restore_cmd(self, event: Select.Changed)-> str:
+    def generate_cmd(self, event: Select.Changed)-> str:
         db = config["dbs"][event.value]
         pg_dump_cmd = self.construct_dump_command(db)
         pg_restore_cmd = self.construct_restore_command(db)

--- a/pg_migration_tool/main.py
+++ b/pg_migration_tool/main.py
@@ -140,7 +140,7 @@ class SelectApp(App):
             return decrypted_password
         except Exception as e:
             self.query_one(Log).write_line(f'{label} Failed to decrypt password with kms key \'{config["common"]["kms_key_id"]}\': {e}')
-        return None
+            return None
 
     def construct_path_to_dump(self, db) -> str:
         path = config["common"]["dumps_working_directory"]


### PR DESCRIPTION
* Add an option to reuse existing dump when restoring database (and as such skip the dump step)
* Add an option to time the execution duration of dump and restore (via built-in `time`)
* Command that will be run is now regenerated and displayed again when any of the relevant parameters change
* Move previous backup deletion to be a part of a command being executed instead of silently ran command
* Focus on the log view before running command so user can read progress status immediately